### PR TITLE
Derive ports in relative paths

### DIFF
--- a/src/webignition/AbsoluteUrlDeriver/AbsoluteUrlDeriver.php
+++ b/src/webignition/AbsoluteUrlDeriver/AbsoluteUrlDeriver.php
@@ -79,6 +79,7 @@ class AbsoluteUrlDeriver {
             } else {
                 $this->derivePath();        
                 $this->deriveHost();
+                $this->derivePort();
                 $this->deriveScheme();
 
                 $this->deriveUser();
@@ -94,6 +95,27 @@ class AbsoluteUrlDeriver {
             }
         }        
     }
+
+    private function derivePort() {
+        if (!$this->absoluteUrl->hasPort()) {
+            if ($this->sourceUrl->hasPort()) {
+                $scheme = null;
+                if ($this->sourceUrl->hasScheme()) {
+                    $scheme = $this->sourceUrl->getScheme();
+                }
+                $port = $this->sourceUrl->getPort();
+                // Note: the Url class seems to add the port specification even 
+                // when the standard HTTPS port is used. So in order for the 
+                // tests (which test "expected" behavior) to pass, don't set the 
+                // port if it is using the standard HTTPS port. However, if the 
+                // scheme is non-https and port 443 is specified, then add the 
+                // port anyway.
+                if ($port != 443 || $scheme != 'https') {
+                    $this->absoluteUrl->setPort($port);
+                }
+            }
+        }
+    }    
     
     private function deriveScheme() {
         if (!$this->absoluteUrl->hasScheme()) {

--- a/tests/webignition/Tests/AbsoluteUrlDeriver/PortResolutionTest.php
+++ b/tests/webignition/Tests/AbsoluteUrlDeriver/PortResolutionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace webignition\Tests\AbsoluteUrlDeriver;
+
+class PortResolutionTest extends BaseTest {
+    public function testAddsNonStandardHttpPortFromSource() {
+        $this->assertDerivedUrl(array(
+            'non-absolute-url' => 'server.php',
+            'source-url' => 'http://www.example.com:8080',
+            'expected-derived-url' => 'http://www.example.com:8080/server.php'
+        ));
+    }
+
+    public function testAddsNonStandardHttpsPortFromSource() {
+        $this->assertDerivedUrl(array(
+            'non-absolute-url' => 'server.php',
+            'source-url' => 'https://www.example.com:8443',
+            'expected-derived-url' => 'https://www.example.com:8443/server.php'
+        ));
+    }
+
+    public function testDefaultHttpPortFromSourceIsRemoved() {
+        $this->assertDerivedUrl(array(
+            'non-absolute-url' => 'server.php',
+            'source-url' => 'http://www.example.com:80',
+            'expected-derived-url' => 'http://www.example.com/server.php'
+        ));
+    }
+
+    public function testDefaultHttpsPortFromSourceIsRemoved() {
+        $this->assertDerivedUrl(array(
+            'non-absolute-url' => 'server.php',
+            'source-url' => 'https://www.example.com:443',
+            'expected-derived-url' => 'https://www.example.com/server.php'
+        ));
+    }
+
+    public function testHttpOverHttpsPortFromSourceIsAdded() {
+        // This is probably a very odd case, but including it for completeness.
+        $this->assertDerivedUrl(array(
+            'non-absolute-url' => 'server.php',
+            'source-url' => 'http://www.example.com:443',
+            'expected-derived-url' => 'http://www.example.com:443/server.php'
+        ));
+    }
+}


### PR DESCRIPTION
This patch was useful to me in my use of absolute-url-deriver.
